### PR TITLE
Add setting to only apply for specific Note, and update localizations

### DIFF
--- a/locale/en.ts
+++ b/locale/en.ts
@@ -19,6 +19,7 @@ export default {
 	settings_end_character_ruby_desc: "The character to replace 》",
 	settings_hide_ruby_unless_hover_name: "Hide ruby unless hover",
 	settings_hide_ruby_unless_hover_desc: "Hides the ruby upper text unless hovered",
+	
 	settings_source_mode_render_name			: "Enable ruby preview in source mode",
 	settings_source_mode_render_desc			: "Turn off if you want to display ruby marks as is in source mode.",
 	settings_ruby_size_name						: "Ruby size",
@@ -30,5 +31,4 @@ export default {
 	settings_donate_name: "Donate",
 	settings_donate_desc	: "If you like this plugin, I would be grateful if you would consider making a donation to support development.",
 	settings_donate_button	: "Buy me a rice ball",
-
 }

--- a/locale/en.ts
+++ b/locale/en.ts
@@ -13,6 +13,8 @@ export default {
 	settings_command_title: "Command",
 	settings_support_title: "Support",
 
+	settings_modify_character_ruby_name: "Customize ruby character",
+	settings_modify_character_ruby_desc: "Enable to customize the ruby character (e.g. 《》→ 〖〗 ) ⚠️ don't turn on it unless you know what you're doing, this might break existing novel ruby functionality",
 	settings_start_character_ruby_name: "Start ruby character",
 	settings_start_character_ruby_desc: "The character to replace 《",
 	settings_end_character_ruby_name: "End ruby character",

--- a/locale/en.ts
+++ b/locale/en.ts
@@ -12,7 +12,13 @@ export default {
 
 	settings_command_title: "Command",
 	settings_support_title: "Support",
-	
+
+	settings_start_character_ruby_name: "Start ruby character",
+	settings_start_character_ruby_desc: "The character to replace 《",
+	settings_end_character_ruby_name: "End ruby character",
+	settings_end_character_ruby_desc: "The character to replace 》",
+	settings_hide_ruby_unless_hover_name: "Hide ruby unless hover",
+	settings_hide_ruby_unless_hover_desc: "Hides the ruby upper text unless hovered",
 	settings_source_mode_render_name			: "Enable ruby preview in source mode",
 	settings_source_mode_render_desc			: "Turn off if you want to display ruby marks as is in source mode.",
 	settings_ruby_size_name						: "Ruby size",

--- a/locale/en.ts
+++ b/locale/en.ts
@@ -20,6 +20,9 @@ export default {
 	settings_hide_ruby_unless_hover_name: "Hide ruby unless hover",
 	settings_hide_ruby_unless_hover_desc: "Hides the ruby upper text unless hovered",
 	
+	settings_enable_pernote_name: "Only Enable ruby for specific notes",
+	settings_enable_pernote_desc: "Enable ruby functionality only for specific note with property 'enable_ruby: true'",
+
 	settings_source_mode_render_name			: "Enable ruby preview in source mode",
 	settings_source_mode_render_desc			: "Turn off if you want to display ruby marks as is in source mode.",
 	settings_ruby_size_name						: "Ruby size",

--- a/locale/ja.ts
+++ b/locale/ja.ts
@@ -12,6 +12,16 @@ export default {
 
 	settings_command_title: "コマンド",
 	settings_support_title: "サポート",
+	
+	settings_start_character_ruby_name: "ルビの開始文字",
+	settings_start_character_ruby_desc: "《 に置き換える文字",
+	settings_end_character_ruby_name: "ルビの終了文字",
+	settings_end_character_ruby_desc: "》 に置き換える文字",
+	settings_hide_ruby_unless_hover_name: "ホバー時以外はルビを非表示",
+	settings_hide_ruby_unless_hover_desc: "ホバーしていない場合、ルビの上部テキストを非表示にします",
+	
+	settings_enable_pernote_name: "特定のノートでルビを有効化",
+	settings_enable_pernote_desc: "特定のノートでのみルビを有効化したい場合（ノートのプロパティで enable_ruby: true を設定）",
 
 	settings_source_mode_render_name			: "ソースモードでルビを表示",
 	settings_source_mode_render_desc			: "ソースモードではルビ記号を入力したままの文字として表示したい場合、オフにしてください",

--- a/locale/ja.ts
+++ b/locale/ja.ts
@@ -13,6 +13,8 @@ export default {
 	settings_command_title: "コマンド",
 	settings_support_title: "サポート",
 	
+	settings_modify_character_ruby_name: "ルビの文字のカスタマイズ",
+	settings_modify_character_ruby_desc: "ルビの文字を変更します（例：《》→〖〗）⚠️ 既存のルビ記法との互換性が失われる可能性があるため、有効化前のバックアップを推奨しま",
 	settings_start_character_ruby_name: "ルビの開始文字",
 	settings_start_character_ruby_desc: "《 に置き換える文字",
 	settings_end_character_ruby_name: "ルビの終了文字",

--- a/locale/zh.ts
+++ b/locale/zh.ts
@@ -20,6 +20,9 @@ export default {
 	settings_hide_ruby_unless_hover_name: "只在悬停时显示注音",
 	settings_hide_ruby_unless_hover_desc: "悬停时显示注音，其他时间隐藏注音",
 	
+	settings_enable_pernote_name: "只为特定笔记启用注音",
+	settings_enable_pernote_desc: "仅在特定笔记（笔记属性中配置 enable_ruby: true）启用注音",
+
 	settings_source_mode_render_name			: "在源码模式下显示注音",
 	settings_source_mode_render_desc			: "如果希望在源码模式下以原始符号显示注音，请关闭此选项",
 	settings_ruby_size_name						: "注音大小",

--- a/locale/zh.ts
+++ b/locale/zh.ts
@@ -13,6 +13,8 @@ export default {
 	settings_command_title: "命令",
 	settings_support_title: "支持",
 
+	settings_modify_character_ruby_name: "自定义注音符号",
+	settings_modify_character_ruby_desc: "是否允许修改注音符号（例如将《》改为【】符号） ⚠️ 请确保你知道自己在做什么，更换符号可能会导致现有的日式小说注音功能受到影响",
 	settings_start_character_ruby_name: "注音起始符号",
 	settings_start_character_ruby_desc: "用来替换默认的 《 符号",
 	settings_end_character_ruby_name: "注音结束符号",
@@ -21,7 +23,7 @@ export default {
 	settings_hide_ruby_unless_hover_desc: "悬停时显示注音，其他时间隐藏注音",
 	
 	settings_enable_pernote_name: "只为特定笔记启用注音",
-	settings_enable_pernote_desc: "仅在特定笔记（笔记属性中配置 enable_ruby: true）启用注音",
+	settings_enable_pernote_desc: "仅在特定笔记内启用注音转换（笔记属性中配置 enable_ruby: true）",
 
 	settings_source_mode_render_name			: "在源码模式下显示注音",
 	settings_source_mode_render_desc			: "如果希望在源码模式下以原始符号显示注音，请关闭此选项",

--- a/locale/zh.ts
+++ b/locale/zh.ts
@@ -1,0 +1,34 @@
+export default {
+	command_insert_novel_ruby: "插入注音",
+	command_insert_novel_dot : "插入着重号",
+	command_remove_novel_ruby: "从选区删除注音",
+
+	ruby_insert_modal_title	: "插入注音",
+	ruby_insert_modal_body	: "正文",
+	ruby_insert_modal_ruby	: "注音",
+	ruby_insert_modal_ok	: "确定",
+
+	notice_insert_novel_dot_no_selection: "请先选择需要添加着重号的正文",
+
+	settings_command_title: "命令",
+	settings_support_title: "支持",
+
+	settings_start_character_ruby_name: "注音起始符号",
+	settings_start_character_ruby_desc: "用来替换默认的 《 符号",
+	settings_end_character_ruby_name: "注音结束符号",
+	settings_end_character_ruby_desc: "用来替换默认的 》 符号",
+	settings_hide_ruby_unless_hover_name: "只在悬停时显示注音",
+	settings_hide_ruby_unless_hover_desc: "悬停时显示注音，其他时间隐藏注音",
+	
+	settings_source_mode_render_name			: "在源码模式下显示注音",
+	settings_source_mode_render_desc			: "如果希望在源码模式下以原始符号显示注音，请关闭此选项",
+	settings_ruby_size_name						: "注音大小",
+	settings_ruby_size_desc						: "以比例指定注音相对于正文的大小 (默认: 0.5)",
+	settings_insert_full_width_separator_name	: "“插入注音”命令使用全角“｜”",
+	settings_insert_full_width_separator_desc	: "如果希望命令插入半角“|”，请关闭此选项 ※不影响显示",
+	settings_emphashis_dot_name					: "着重号字符",
+	settings_emphashis_dot_desc					: "指定“插入着重号”命令插入的字符。仅保存第一个字符",
+	settings_donate_name	: "捐赠",
+	settings_donate_desc	: "如果您喜欢这个插件，欢迎考虑捐赠以支持开发",
+	settings_donate_button	: "请我吃一个饭团",
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "japanese-novel-ruby",
 	"name": "Japanese Novel Ruby",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"minAppVersion": "1.4.0",
 	"description": "Treat ruby(Furigana) ​​marks commonly used in Japanese novels.",
 	"author": "quels <@k-quels>",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "japanese-novel-ruby",
-	"version": "1.0.0",
+	"version": "1.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "japanese-novel-ruby",
-			"version": "1.0.0",
+			"version": "1.1.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@types/node": "^16.11.6",

--- a/src/NovelRubyPostProcessor.ts
+++ b/src/NovelRubyPostProcessor.ts
@@ -1,19 +1,22 @@
-import { MarkdownPostProcessor, MarkdownPostProcessorContext } from "obsidian";
+import { MarkdownPostProcessorContext } from "obsidian";
 
-import { RUBY_REGEXP } from "./main";
+import {NovelRubyPluginSettings, RubyRegex} from "./main";
 
 /**
 	Convert ruby marks to tag for MarkdownPostProcessor
 */
-export const convertNovelRuby = (element: Text): Node => {
+export const convertNovelRuby = (element: Text, hide: boolean = false): Node => {
 	if (element.textContent) {
-		const matches = Array.from(element.textContent.matchAll(RUBY_REGEXP));
+		const matches = Array.from(element.textContent.matchAll(RubyRegex.RUBY_REGEXP));
 		let lastNode = element;
 		for (const match of matches) {
 			const ruby = match.groups!.ruby; // if there is a match, there must be a ruby
 			const body = match.groups?.body1 ? match.groups!.body1 : match.groups!.body2;
 			// Set up ruby tag
 			const rubyNode = document.createElement('ruby');
+			if (hide){
+				rubyNode.addClass('ruby-hide');
+			}
 			rubyNode.addClass('ruby');
 			rubyNode.appendText(body);
 			rubyNode.createEl('rt', { text: ruby });
@@ -31,7 +34,7 @@ export const convertNovelRuby = (element: Text): Node => {
 /**
  * Ruby convert MarkdownPostProcessor - for reading view
  */
-export const novelRubyPostProcessor: MarkdownPostProcessor = (e: HTMLElement, ctx: MarkdownPostProcessorContext) => {
+export const novelRubyPostProcessor = (e: HTMLElement, ctx: MarkdownPostProcessorContext, settings?: NovelRubyPluginSettings) => {
 	const searchBlock = e.querySelectorAll('p, h1, h2, h3, h4, h5, h6, ol, ul, table');
 	if (searchBlock.length === 0) return;
 
@@ -48,7 +51,7 @@ export const novelRubyPostProcessor: MarkdownPostProcessor = (e: HTMLElement, ct
 		});
 		// Convert ruby marks to ruby tags
 		children.forEach((child) => {
-			child.replaceWith(convertNovelRuby(child));
+			child.replaceWith(convertNovelRuby(child, settings?.hideRuby));
 		});
 	}
 

--- a/src/NovelRubyPostProcessor.ts
+++ b/src/NovelRubyPostProcessor.ts
@@ -2,6 +2,22 @@ import { MarkdownPostProcessorContext } from "obsidian";
 
 import {NovelRubyPluginSettings, RubyRegex} from "./main";
 
+function shouldEnableForNote(settings : NovelRubyPluginSettings): boolean {
+	if (!settings.enablePerNote) {
+		return true; // 全局启用
+	}
+	const activeFile = this.app.workspace.getActiveFile();
+	if (!activeFile) {
+		return false; // 如果没有活动文件，则功能不生效
+	}
+	const frontmatter = this.app.metadataCache.getFileCache(activeFile)?.frontmatter;
+	if (frontmatter && frontmatter["enable_ruby"] !== undefined) {
+		return frontmatter["enable_ruby"] === true; // 根据 frontmatter 判断
+	}
+	return false;
+}
+
+
 /**
 	Convert ruby marks to tag for MarkdownPostProcessor
 */

--- a/src/NovelRubySettingTab.ts
+++ b/src/NovelRubySettingTab.ts
@@ -17,6 +17,16 @@ export class NovelRubySettingTab extends PluginSettingTab {
 		containerEl.empty();
 
 		new Setting(containerEl)
+			.setName(t("settings_enable_pernote_name"))
+			.setDesc(t("settings_enable_pernote_desc"))
+			.addToggle(text => text
+				.setValue(this.plugin.settings.enablePerNote)
+				.onChange(async (value) => {
+					this.plugin.settings.enablePerNote = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
 			.setName(t("settings_source_mode_render_name"))
 			.setDesc(t("settings_source_mode_render_desc"))
 			.addToggle(text => text

--- a/src/NovelRubySettingTab.ts
+++ b/src/NovelRubySettingTab.ts
@@ -1,6 +1,6 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import {App, PluginSettingTab, Setting} from "obsidian";
 
-import NovelRubyPlugin from "./main";
+import NovelRubyPlugin, {RubyRegex} from "./main";
 import t from "./l10n";
 
 export class NovelRubySettingTab extends PluginSettingTab {
@@ -12,7 +12,7 @@ export class NovelRubySettingTab extends PluginSettingTab {
 	}
 
 	display(): void {
-		const { containerEl } = this;
+		const {containerEl} = this;
 
 		containerEl.empty();
 
@@ -25,7 +25,7 @@ export class NovelRubySettingTab extends PluginSettingTab {
 					this.plugin.settings.sourceModeRendering = value;
 					await this.plugin.saveSettings();
 				}));
-		
+
 		new Setting(containerEl)
 			.setName(t("settings_ruby_size_name"))
 			.setDesc(t("settings_ruby_size_desc"))
@@ -33,13 +33,45 @@ export class NovelRubySettingTab extends PluginSettingTab {
 				.setValue(String(this.plugin.settings.rubySize))
 				.setPlaceholder("0.5")
 				.onChange(async (value) => {
-					const saveValue : number = Number(value) ? Number(value) : 0.5;
+					const saveValue: number = Number(value) ? Number(value) : 0.5;
 					this.plugin.settings.rubySize = saveValue;
 					await this.plugin.saveSettings();
 				}));
-		
-		new Setting(containerEl).setName(t("settings_command_title")).setHeading();
 
+		new Setting(containerEl).setName(t("settings_command_title")).setHeading();
+		new Setting(containerEl)
+			.setName(t("settings_start_character_ruby_name"))
+			.setDesc(t("settings_start_character_ruby_desc"))
+			.addText(text => text
+				.setValue(this.plugin.settings.startRubyCharacter)
+				.onChange(async (value) => {
+					this.plugin.settings.startRubyCharacter = value;
+					await this.plugin.saveSettings();
+					RubyRegex.changeRubyRegexp(this.plugin.settings.startRubyCharacter, this.plugin.settings.endRubyCharacter);
+				})
+			);
+		new Setting(containerEl)
+			.setName(t("settings_end_character_ruby_name"))
+			.setDesc(t("settings_end_character_ruby_desc"))
+			.addText(text => text
+				.setValue(this.plugin.settings.endRubyCharacter)
+				.onChange(async (value) => {
+					this.plugin.settings.endRubyCharacter = value;
+					await this.plugin.saveSettings();
+					RubyRegex.changeRubyRegexp(this.plugin.settings.startRubyCharacter, this.plugin.settings.endRubyCharacter);
+				})
+			);
+		new Setting(containerEl)
+			.setName(t("settings_hide_ruby_unless_hover_name"))
+			.setDesc(t("settings_hide_ruby_unless_hover_name"))
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.hideRuby)
+				.onChange(async (value) => {
+					this.plugin.settings.hideRuby = value;
+					await this.plugin.saveSettings();
+					RubyRegex.changeRubyRegexp(this.plugin.settings.startRubyCharacter, this.plugin.settings.endRubyCharacter);
+				})
+			);
 		new Setting(containerEl)
 			.setName(t("settings_insert_full_width_separator_name"))
 			.setDesc(t("settings_insert_full_width_separator_desc"))
@@ -49,7 +81,7 @@ export class NovelRubySettingTab extends PluginSettingTab {
 					this.plugin.settings.insertFullWidthMark = value;
 					await this.plugin.saveSettings();
 				}));
-		
+
 		new Setting(containerEl)
 			.setName(t("settings_emphashis_dot_name"))
 			.setDesc(t("settings_emphashis_dot_desc"))
@@ -59,9 +91,9 @@ export class NovelRubySettingTab extends PluginSettingTab {
 					this.plugin.settings.emphasisDot = value[0];
 					await this.plugin.saveSettings();
 				}));
-		
+
 		new Setting(containerEl).setName(t("settings_support_title")).setHeading();
-		
+
 		new Setting(containerEl)
 			.setName(t("settings_donate_name"))
 			.setDesc(t("settings_donate_desc"))

--- a/src/NovelRubySettingTab.ts
+++ b/src/NovelRubySettingTab.ts
@@ -49,28 +49,54 @@ export class NovelRubySettingTab extends PluginSettingTab {
 				}));
 
 		new Setting(containerEl).setName(t("settings_command_title")).setHeading();
+
+		
 		new Setting(containerEl)
-			.setName(t("settings_start_character_ruby_name"))
-			.setDesc(t("settings_start_character_ruby_desc"))
-			.addText(text => text
-				.setValue(this.plugin.settings.startRubyCharacter)
+			.setName(t("settings_modify_character_ruby_name"))
+			.setDesc(t("settings_modify_character_ruby_desc"))
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.modifyRubyCharacter)
 				.onChange(async (value) => {
-					this.plugin.settings.startRubyCharacter = value;
+					this.plugin.settings.modifyRubyCharacter = value;
 					await this.plugin.saveSettings();
-					RubyRegex.changeRubyRegexp(this.plugin.settings.startRubyCharacter, this.plugin.settings.endRubyCharacter);
+
+					// Switch the ruby regexp when toggled.
+					if (!value) {
+						RubyRegex.resetRubyRegexp();
+					} else {
+						RubyRegex.changeRubyRegexp(this.plugin.settings.startRubyCharacter, this.plugin.settings.endRubyCharacter);
+					}
+
+					this.display();
 				})
 			);
-		new Setting(containerEl)
-			.setName(t("settings_end_character_ruby_name"))
-			.setDesc(t("settings_end_character_ruby_desc"))
-			.addText(text => text
-				.setValue(this.plugin.settings.endRubyCharacter)
-				.onChange(async (value) => {
-					this.plugin.settings.endRubyCharacter = value;
-					await this.plugin.saveSettings();
-					RubyRegex.changeRubyRegexp(this.plugin.settings.startRubyCharacter, this.plugin.settings.endRubyCharacter);
-				})
-			);
+
+		if (this.plugin.settings.modifyRubyCharacter) {
+			new Setting(containerEl)
+				.setName(t("settings_start_character_ruby_name"))
+				.setDesc(t("settings_start_character_ruby_desc"))
+				.addText(text => text
+					.setValue(this.plugin.settings.startRubyCharacter)
+					.onChange(async (value) => {
+						this.plugin.settings.startRubyCharacter = value;
+						await this.plugin.saveSettings();
+						RubyRegex.changeRubyRegexp(this.plugin.settings.startRubyCharacter, this.plugin.settings.endRubyCharacter);
+					})
+				);
+
+			new Setting(containerEl)
+				.setName(t("settings_end_character_ruby_name"))
+				.setDesc(t("settings_end_character_ruby_desc"))
+				.addText(text => text
+					.setValue(this.plugin.settings.endRubyCharacter)
+					.onChange(async (value) => {
+						this.plugin.settings.endRubyCharacter = value;
+						await this.plugin.saveSettings();
+						RubyRegex.changeRubyRegexp(this.plugin.settings.startRubyCharacter, this.plugin.settings.endRubyCharacter);
+					})
+				);
+		}
+
 		new Setting(containerEl)
 			.setName(t("settings_hide_ruby_unless_hover_name"))
 			.setDesc(t("settings_hide_ruby_unless_hover_name"))

--- a/src/NovelRubyViewPlugin.ts
+++ b/src/NovelRubyViewPlugin.ts
@@ -1,35 +1,37 @@
-import { App } from "obsidian";
-import { ViewPlugin, WidgetType, ViewUpdate, Decoration, DecorationSet, EditorView } from '@codemirror/view';
-import { RangeSetBuilder } from "@codemirror/state";
-import { editorLivePreviewField } from 'obsidian';
+import {App} from "obsidian";
+import {ViewPlugin, WidgetType, ViewUpdate, Decoration, DecorationSet, EditorView} from '@codemirror/view';
+import {RangeSetBuilder} from "@codemirror/state";
+import {editorLivePreviewField} from 'obsidian';
 
-import NovelRubyPlugin from "./main";
-import { RUBY_REGEXP } from "./main";
+import NovelRubyPlugin, {RubyRegex} from "./main";
 
 /**
 	Tag insert widget for View Plugin
-*/
+ */
 class NovelRubyWidget extends WidgetType {
-	constructor(readonly body: string, readonly ruby: string) {
+	constructor(readonly body: string, readonly ruby: string, readonly hide: boolean = false) {
 		super();
 	}
 
 	toDOM(view: EditorView): HTMLElement {
 		const ruby = document.createElement('ruby');
+		if (this.hide) {
+			ruby.className = "ruby-hide";
+		}
 		ruby.appendText(this.body);
-		ruby.createEl('rt', { text: this.ruby });
+		ruby.createEl('rt', {text: this.ruby});
 		return ruby;
 	}
 }
 
 /**
 	View Plugin wrapper function for access to plugin settings - for editor view
-*/
+ */
 export function novelRubyExtension(app: App, plugin: NovelRubyPlugin) {
 	return ViewPlugin.fromClass(class {
 		decorations: DecorationSet;
 		sourceModeRendering: boolean; // needs to detect setting change
-	
+
 		constructor(view: EditorView) {
 			this.decorations = this.updateDecorations(view);
 			this.sourceModeRendering = plugin.settings.sourceModeRendering;
@@ -39,14 +41,15 @@ export function novelRubyExtension(app: App, plugin: NovelRubyPlugin) {
 			if (update.docChanged || update.viewportChanged || update.selectionSet ||
 				(update.startState.field(editorLivePreviewField) != update.state.field(editorLivePreviewField)) ||
 				(!update.startState.field(editorLivePreviewField) && (this.sourceModeRendering != plugin.settings.sourceModeRendering))) {
-				if (this.sourceModeRendering != plugin.settings.sourceModeRendering){
+				if (this.sourceModeRendering != plugin.settings.sourceModeRendering) {
 					this.sourceModeRendering = plugin.settings.sourceModeRendering; // apply setting to view plugin
 				}
 				this.decorations = this.updateDecorations(update.view);
 			}
 		}
 
-		destroy() { }
+		destroy() {
+		}
 
 		/**
 		 * Set up DecorationSet with setting & mode check
@@ -61,7 +64,7 @@ export function novelRubyExtension(app: App, plugin: NovelRubyPlugin) {
 
 		/**
 		 * Convert ruby marks to tag
-		*/
+		 */
 		buildDecorations(view: EditorView): DecorationSet {
 			const builder = new RangeSetBuilder<Decoration>();
 			const selections = [...view.state.selection.ranges];
@@ -76,7 +79,7 @@ export function novelRubyExtension(app: App, plugin: NovelRubyPlugin) {
 				// search ruby & decorate
 				for (let pos = viewRange.from; pos <= viewRange.to;) {
 					const line = view.state.doc.lineAt(pos);
-					const matches = Array.from(line.text.matchAll(RUBY_REGEXP));
+					const matches = Array.from(line.text.matchAll(RubyRegex.RUBY_REGEXP));
 					for (const match of matches) {
 						let add = true;
 						const ruby = match.groups!.ruby; // if there is a match, there will be ruby
@@ -90,7 +93,7 @@ export function novelRubyExtension(app: App, plugin: NovelRubyPlugin) {
 							}
 						})
 						if (add) {
-							builder.add(from, to, Decoration.widget({ widget: new NovelRubyWidget(body, ruby) }))
+							builder.add(from, to, Decoration.widget({widget: new NovelRubyWidget(body, ruby, plugin.settings.hideRuby)}))
 						}
 					}
 					pos = line.to + 1;

--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -1,10 +1,12 @@
 import { moment } from "obsidian";
 import en from "../locale/en";
 import ja from "../locale/ja";
+import zh from "../locale/zh";
 
 const localeMap = {
 	en,
 	ja,
+	zh,
 }
 
 const locale = localeMap[moment.locale() as keyof typeof localeMap];

--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -6,7 +6,8 @@ import zh from "../locale/zh";
 const localeMap = {
 	en,
 	ja,
-	zh,
+	"zh-cn": zh,
+	zh: zh,
 }
 
 const locale = localeMap[moment.locale() as keyof typeof localeMap];

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,7 +27,8 @@ export interface NovelRubyPluginSettings {
 	endRubyCharacter: string,
 	hideRuby: boolean,
 	emphasisDot: string,
-	rubySize: number
+	rubySize: number,
+	enablePerNote: boolean
 }
 
 const DEFAULT_SETTINGS: NovelRubyPluginSettings = {
@@ -37,7 +38,8 @@ const DEFAULT_SETTINGS: NovelRubyPluginSettings = {
 	endRubyCharacter: "》",
 	hideRuby: false,
 	emphasisDot: '・',
-	rubySize: 0.5
+	rubySize: 0.5,
+	enablePerNote: false // Disable by default
 }
 
 export default class NovelRubyPlugin extends Plugin {
@@ -46,7 +48,11 @@ export default class NovelRubyPlugin extends Plugin {
 	async onload() {
 		await this.loadSettings();
 		RubyRegex.changeRubyRegexp(this.settings.startRubyCharacter, this.settings.endRubyCharacter);
-		this.registerMarkdownPostProcessor((el, ctx) => novelRubyPostProcessor(el, ctx, this.settings));
+
+		this.registerMarkdownPostProcessor((el, ctx) => {
+			novelRubyPostProcessor(el, ctx, this.settings);
+		});
+
 		this.registerEditorExtension(novelRubyExtension(this.app, this)); // affect to editor (source or live-preview)
 
 		// Display ruby insert modal

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,11 +18,16 @@ export class RubyRegex {
 	static changeRubyRegexp(start: string, end: string) {
 		RubyRegex.RUBY_REGEXP = RubyRegex.createRubyRegexp(start, end);
 	}
+	
+	static resetRubyRegexp() {
+		RubyRegex.RUBY_REGEXP = RubyRegex.createRubyRegexp("《", "》");
+	}
 }
 
 export interface NovelRubyPluginSettings {
 	sourceModeRendering: boolean,
 	insertFullWidthMark: boolean,
+	modifyRubyCharacter: boolean,
 	startRubyCharacter: string,
 	endRubyCharacter: string,
 	hideRuby: boolean,
@@ -34,6 +39,7 @@ export interface NovelRubyPluginSettings {
 const DEFAULT_SETTINGS: NovelRubyPluginSettings = {
 	sourceModeRendering: true,
 	insertFullWidthMark: true,
+	modifyRubyCharacter: false,
 	startRubyCharacter: "《",
 	endRubyCharacter: "》",
 	hideRuby: false,

--- a/styles.css
+++ b/styles.css
@@ -2,3 +2,11 @@ ruby > rt {
 	font-size: 100%;
 	zoom: var(--ruby-size);
 }
+
+ruby.ruby-hide rt {
+	display: none;
+}
+
+ruby.ruby-hide:hover rt {
+	display: ruby-text;
+}


### PR DESCRIPTION
**This commit is based on #2** 

I added a new setting: `setPerNote`
When enabling, this plugin will only render the note with `enable_ruby` property, rather than all notes.
![image](https://github.com/user-attachments/assets/bd2cd7cc-9de8-4665-992f-26cd132b73ca)

And I also updated the localization for new terms, as well as added Chinese localizations.
