### PR TITLE
Traditional Chinese Localization & Shortcut for positioning ruby to corresponding character

### DIFF
--- a/locale/zh-tw.ts
+++ b/locale/zh-tw.ts
@@ -1,0 +1,41 @@
+export default {
+	command_insert_novel_ruby: "插入注音",
+	command_insert_novel_dot : "插入著重號",
+	command_remove_novel_ruby: "刪除已選取文字的注音",
+
+	ruby_insert_modal_title	: "插入注音",
+	ruby_insert_modal_body	: "正文",
+	ruby_insert_modal_ruby	: "注音",
+	ruby_insert_modal_ok	: "確定",
+
+	notice_insert_novel_dot_no_selection: "請先選擇需要添加著重號的正文",
+
+	settings_display_title: "顯示",
+	settings_ruby_size_name					: "注音大小",
+	settings_ruby_size_desc					: "以比例指定注音相對於正文的大小 (預設: 0.5)",
+	settings_source_mode_render_name		: "在源碼模式下顯示注音",
+	settings_source_mode_render_desc		: "如果希望在源碼模式下以原始符號顯示注音，請關閉此選項",
+	settings_hide_ruby_unless_hover_name	: "只在懸停時顯示注音",
+	settings_hide_ruby_unless_hover_desc	: "懸停時顯示注音，其他時間隱藏注音",
+
+	settings_command_title: "命令",
+	settings_insert_full_width_separator_name	: "「插入注音」命令使用全形「｜」",
+	settings_insert_full_width_separator_desc	: "如果希望命令插入半形「 | 」，請關閉此選項 ※不影響顯示",
+	settings_emphashis_dot_name					: "著重號字元",
+	settings_emphashis_dot_desc					: "指定「插入著重號」命令插入的字元。僅儲存第一個字元",
+
+	settings_advanced_title: "高級設定",
+	settings_enable_pernote_name: "僅為特定筆記啟用注音",
+	settings_enable_pernote_desc: "僅在特定筆記內啟用注音轉換（筆記屬性中配置 enable_ruby: true）",
+	settings_modify_character_ruby_name: "自訂注音符號",
+	settings_modify_character_ruby_desc: "是否允許修改注音符號（例如將《》改為【】符號） ⚠️ 請確保你知道自己在做什麼，更換符號可能會導致現有的日式小說注音功能受到影響",
+	settings_start_character_ruby_name: "注音開始符號",
+	settings_start_character_ruby_desc: "用來替換預設的 《 符號 *現有符號不會被自動替換。",
+	settings_end_character_ruby_name: "注音結束符號",
+	settings_end_character_ruby_desc: "用來替換預設的 》 符號 *現有符號不會被自動替換。",
+
+	settings_support_title: "支持",
+	settings_donate_name	: "捐贈",
+	settings_donate_desc	: "如果您喜歡這個插件，歡迎考慮捐贈以支持開發",
+	settings_donate_button	: "請我吃一個飯糰",
+}

--- a/src/NovelRubyViewPlugin.ts
+++ b/src/NovelRubyViewPlugin.ts
@@ -42,6 +42,28 @@ class NovelRubyWidget extends WidgetType {
 	}
 }
 
+class NovelRubyWithSeparatorsWidget extends WidgetType {
+	constructor(readonly body: string, readonly ruby: string, readonly hide: boolean = false, readonly sep='｜') {
+		super();
+	}
+
+	toDOM(view: EditorView): HTMLElement {
+		const rubyNode = document.createElement('ruby');
+		if (this.hide) {
+			rubyNode.className = "ruby-hide";
+		}
+		const rubies = this.ruby.split(this.sep)
+		for (let i = 0; i < this.body.length; i++) {
+			rubyNode.appendText(this.body[i])
+			if (i > rubies.length) {
+				continue
+			}
+			rubyNode.createEl('rt', {text: rubies[i]});
+		}
+		return rubyNode;
+	}
+}
+
 /**
 	View Plugin wrapper function for access to plugin settings - for editor view
  */
@@ -131,7 +153,7 @@ export function novelRubyExtension(app: App, plugin: NovelRubyPlugin) {
 							}
 						})
 						if (add) {
-							builder.add(from, to, Decoration.widget({widget: new NovelRubyWidget(body, ruby, plugin.settings.hideRuby)}))
+							builder.add(from, to, Decoration.widget({widget: new NovelRubyWithSeparatorsWidget(body, ruby, plugin.settings.hideRuby)}))
 						}
 					}
 					pos = line.to + 1;

--- a/src/l10n.ts
+++ b/src/l10n.ts
@@ -1,13 +1,15 @@
 import { moment } from "obsidian";
 import en from "../locale/en";
 import ja from "../locale/ja";
-import zh from "../locale/zh";
+import chs from "../locale/zh"; // Chinese (Simplified)
+import cht from "../locale/zh-tw"; // Chinese (Traditional)
 
 const localeMap = {
 	en,
 	ja,
-	"zh-cn": zh,
-	zh: zh,
+	zh: chs,
+	"zh-cn": chs,
+	"zh-tw": cht,
 }
 
 const locale = localeMap[moment.locale() as keyof typeof localeMap];


### PR DESCRIPTION
The shortcut is like the following examples:
```
日本語《に｜ほん｜ご》 = 日《に》本《ほん》語《ご》
短い間《みじか｜｜あいだ》 = 短《みじか》い間《あいだ》
```
User can type less 《》 in this way if they want the ruby positioned more precisely.